### PR TITLE
Destination can be a file or folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ svgeez is a command line program with several useful subcommands. From the root 
 
 ### The `build` command
 
-You can manually generate an SVG sprite from a folder of SVGs with the `build` command which takes two options, a path to your folder of individual SVGs and a path to the desired output folder. _These paths must be different!_
+You can manually generate an SVG sprite from a folder of SVGs with the `build` command which takes two options, a path to your folder of individual SVGs and a path to the desired destination folder. _These paths must be different!_
 
 A basic example:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The above example will combine all SVG files in `~/Sites/sixtwothree.org/images/
 
 #### Options and Defaults
 
+|Option|Description|
 |---|---|
 |`-s`<br>`--source`|Path to the folder of source SVGs (defaults to `./`).|
 |`-d`<br>`--destination`|Path to the destination file or folder (defaults to `./_svgeez/svgeez.svg`)|

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem Version](https://badge.fury.io/rb/svgeez.svg)](https://badge.fury.io/rb/svgeez)
 [![Build Status](https://travis-ci.org/jgarber623/svgeez.svg?branch=master)](https://travis-ci.org/jgarber623/svgeez)
 
-If you're using an [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) icon system in your Web projects, svgeez can help speed up your workflow by automating the SVG sprite generation process. Simply run svgeez alongside your existing project (or integrate it into your current build system); add, edit, or delete SVG files from a directory; and marvel as svgeez generates a single SVG sprite file ready for inclusion in your user interface.
+If you're using an [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) icon system in your Web projects, svgeez can help speed up your workflow by automating the SVG sprite generation process. Simply run svgeez alongside your existing project (or integrate it into your current build system); add, edit, or delete SVG files from a folder; and marvel as svgeez generates a single SVG sprite file ready for inclusion in your user interface.
 
 _For more on why SVG sprites are the bee's knees as far as icon systems go, give Chris Coyier's original post, [Icon System with SVG Sprites](https://css-tricks.com/svg-sprites-use-better-icon-fonts/), and his follow-up article, [SVG \`symbol\` a Good Choice for Icons](https://css-tricks.com/svg-symbol-good-choice-icons/) a read-through._
 
@@ -77,7 +77,7 @@ If you have the excellent [SVGO](https://github.com/svg/svgo/) utility installed
 $ svgeez build --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images --with-svgo
 ```
 
-Optimizing source SVG files with SVGO is done on-the-fly and the original files are left intact. Depending on the number of individual SVG files in the source directory, using the `--with-svgo` option can add considerable time to SVG sprite generation.
+Optimizing source SVG files with SVGO is done on-the-fly and the original files are left intact. Depending on the number of individual SVG files in the source folder, using the `--with-svgo` option can add considerable time to SVG sprite generation.
 
 ## Working with SVG sprites
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/svgeez.svg)](https://badge.fury.io/rb/svgeez)
 [![Build Status](https://travis-ci.org/jgarber623/svgeez.svg?branch=master)](https://travis-ci.org/jgarber623/svgeez)
+[![Code Climate](https://codeclimate.com/github/jgarber623/svgeez/badges/gpa.svg)](https://codeclimate.com/github/jgarber623/svgeez)
 
 If you're using an [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) icon system in your Web projects, svgeez can help speed up your workflow by automating the SVG sprite generation process. Simply run svgeez alongside your existing project (or integrate it into your current build system); add, edit, or delete SVG files from a folder; and marvel as svgeez generates a single SVG sprite file ready for inclusion in your user interface.
 
@@ -52,10 +53,17 @@ You can manually generate an SVG sprite from a folder of SVGs with the `build` c
 A basic example:
 
 ```sh
-$ svgeez build --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images
+$ svgeez build --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images/icons.svg
 ```
 
-The above example will combine all SVG files in `~/Sites/sixtwothree.org/images/icons` into a single SVG sprite in `~/Sites/sixtwothree.org/images`. The resulting sprite file will be named `icons.svg` (this file name is derived from the name of the provided source folder).
+The above example will combine all SVG files in `~/Sites/sixtwothree.org/images/icons` into a single SVG sprite file (`icons.svg`) in `~/Sites/sixtwothree.org/images`.
+
+#### Options and Defaults
+
+|---|---|
+|`-s`<br>`--source`|Path to the folder of source SVGs (defaults to `./`).|
+|`-d`<br>`--destination`|Path to the destination file or folder (defaults to `./_svgeez/svgeez.svg`)|
+|`--with-svgo`|Optimize source SVGs with [SVGO](https://github.com/svg/svgo/) before sprite generation (non-destructive)|
 
 ### The `watch` command
 
@@ -64,7 +72,7 @@ The `watch` command takes the same arguments as the `build` command but uses the
 Tweaking the example from above:
 
 ```sh
-$ svgeez watch --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images
+$ svgeez watch --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images/icons.svg
 ```
 
 svgeez will remaing running, watching for new, removed, or updated SVG files in the provided source folder. As SVG files are added, deleted, or modified in the source folder, svgeez will keep pumping out updated SVG sprite files to the destination folder.
@@ -74,7 +82,7 @@ svgeez will remaing running, watching for new, removed, or updated SVG files in 
 If you have the excellent [SVGO](https://github.com/svg/svgo/) utility installed on your system (and the `svgo` command is available in your PATH), you can use the `--with-svgo` option and optimize source SVGs before generating the sprite file.
 
 ```sh
-$ svgeez build --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images --with-svgo
+$ svgeez build --source ~/Sites/sixtwothree.org/images/icons --destination ~/Sites/sixtwothree.org/images/icons.svg --with-svgo
 ```
 
 Optimizing source SVG files with SVGO is done on-the-fly and the original files are left intact. Depending on the number of individual SVG files in the source folder, using the `--with-svgo` option can add considerable time to SVG sprite generation.

--- a/lib/svgeez/command.rb
+++ b/lib/svgeez/command.rb
@@ -11,8 +11,8 @@ module Svgeez
       end
 
       def add_build_options(c)
-        c.option 'source', '-s', '--source [DIR]', 'Source directory (defaults to ./)'
-        c.option 'destination', '-d', '--destination [DIR]', 'Destination directory (defaults to ./_svgeez)'
+        c.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./)'
+        c.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./_svgeez/svgeez.svg)'
         c.option 'svgo', '--with-svgo', 'Optimize source SVGs with SVGO before sprite generation (non-destructive)'
       end
     end

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -34,19 +34,23 @@ module Svgeez
     end
 
     def build_destination_file_contents
-      %{<svg id="#{source_basename}" style="display: none;" version="1.1">}.tap do |destination_file_contents|
+      %{<svg id="#{destination_file_id}" style="display: none;" version="1.1">}.tap do |destination_file_contents|
         # Loop over all source files, grabbing their content, and appending to `destination_file_contents`
         source_file_paths.each do |file_path|
           file_contents = use_svgo? ? `svgo -i #{file_path} -o -` : IO.read(file_path)
           pattern = /^<svg.*?(?<viewbox>viewBox=".*?").*?>(?<content>.*?)<\/svg>/m
 
           file_contents.match(pattern) do |matches|
-            destination_file_contents << %{<symbol id="#{source_basename}-#{File.basename(file_path, '.svg').downcase}" #{matches[:viewbox]}>#{matches[:content]}</symbol>}
+            destination_file_contents << %{<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').downcase}" #{matches[:viewbox]}>#{matches[:content]}</symbol>}
           end
         end
 
         destination_file_contents << '</svg>'
       end
+    end
+
+    def destination_file_id
+      @destination_file_id ||= source_basename.gsub(' ', '-')
     end
 
     def destination_file_path

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -50,7 +50,7 @@ module Svgeez
     end
 
     def destination_file_path
-      File.join(@destination, %{#{source_basename}.svg})
+      @destination_file_path ||= File.join(@destination, %{#{source_basename}.svg})
     end
 
     def source_basename
@@ -58,7 +58,7 @@ module Svgeez
     end
 
     def source_file_paths
-      Dir.glob(File.join(@source, '*.svg'))
+      @source_file_paths ||= Dir.glob(File.join(@source, '*.svg'))
     end
 
     def source_is_destination?

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -2,7 +2,7 @@ module Svgeez
   class SpriteBuilder
     def initialize(options)
       @source = File.expand_path(options.fetch('source', './'))
-      @destination = File.expand_path(options.fetch('destination', './_svgeez'))
+      @destination = File.expand_path(options.fetch('destination', './_svgeez/svgeez.svg'))
       @with_svgo = options['svgo']
     end
 
@@ -11,8 +11,8 @@ module Svgeez
         if source_file_paths.any?
           Svgeez.logger.info %{Generating sprite at `#{destination_file_path}` from #{source_file_paths.length} SVG#{'s' if source_file_paths.length > 1}...}
 
-          # Make destination directory
-          FileUtils.mkdir_p(@destination)
+          # Make destination folder
+          FileUtils.mkdir_p(destination_folder_path)
 
           # Notify if SVGO requested but not found
           if @with_svgo && !svgo_installed?
@@ -50,15 +50,27 @@ module Svgeez
     end
 
     def destination_file_id
-      @destination_file_id ||= source_basename.gsub(' ', '-')
+      @destination_file_id ||= File.basename(destination_file_name, '.svg').gsub(' ', '-')
+    end
+
+    def destination_file_name
+      if @destination.end_with?('.svg')
+        File.split(@destination)[1]
+      else
+        'svgeez.svg'
+      end
     end
 
     def destination_file_path
-      @destination_file_path ||= File.join(@destination, %{#{source_basename}.svg})
+      @destination_file_path ||= File.join(destination_folder_path, destination_file_name)
     end
 
-    def source_basename
-      @source_basename ||= File.basename(@source)
+    def destination_folder_path
+      if @destination.end_with?('.svg')
+        File.split(@destination)[0]
+      else
+        @destination
+      end
     end
 
     def source_file_paths
@@ -66,7 +78,7 @@ module Svgeez
     end
 
     def source_is_destination?
-      @source == @destination
+      @source == destination_folder_path
     end
 
     def svgo_installed?

--- a/lib/svgeez/version.rb
+++ b/lib/svgeez/version.rb
@@ -1,3 +1,3 @@
 module Svgeez
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/spec/lib/sprite_builder_spec.rb
+++ b/spec/lib/sprite_builder_spec.rb
@@ -1,18 +1,13 @@
 require 'spec_helper'
 
 describe Svgeez::SpriteBuilder do
-  let :options do
-    {
-      'source' => './spec/fixtures/icons',
-      'destination' => './spec/fixtures'
-    }
-  end
-
-  let(:sprite_builder) { Svgeez::SpriteBuilder.new(options) }
-
-  context '#build_output_file_contents' do
+  context '#build_destination_file_contents' do
     it 'should return a string representation of combined SVG files.' do
-      expect(sprite_builder.build_output_file_contents).to eq(IO.read('./spec/fixtures/icons.svg'))
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'source' => './spec/fixtures/icons'
+      })
+
+      expect(sprite_builder.build_destination_file_contents).to eq(IO.read('./spec/fixtures/icons.svg'))
     end
   end
 end

--- a/spec/lib/sprite_builder_spec.rb
+++ b/spec/lib/sprite_builder_spec.rb
@@ -4,10 +4,75 @@ describe Svgeez::SpriteBuilder do
   context '#build_destination_file_contents' do
     it 'should return a string representation of combined SVG files.' do
       sprite_builder = Svgeez::SpriteBuilder.new({
-        'source' => './spec/fixtures/icons'
+        'source' => './spec/fixtures/icons',
+        'destination' => './spec/fixtures/icons.svg'
       })
 
       expect(sprite_builder.build_destination_file_contents).to eq(IO.read('./spec/fixtures/icons.svg'))
+    end
+  end
+
+  context '#destination_file_id' do
+    it 'should return a string when @destination is not specified.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({})
+
+      expect(sprite_builder.destination_file_id).to eq('svgeez')
+    end
+
+    it 'should return a string when @destination is specified.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'destination' => './foo.svg'
+      })
+
+      expect(sprite_builder.destination_file_id).to eq('foo')
+    end
+  end
+
+  context '#destination_file_path' do
+    it 'should return a path when @destination is not specified.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({})
+
+      expect(sprite_builder.destination_file_path).to eq(%{#{Dir.pwd}/_svgeez/svgeez.svg})
+    end
+
+    it 'should return a path when @destination quacks like a folder.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'destination' => './foo'
+      })
+
+      expect(sprite_builder.destination_file_path).to eq("#{Dir.pwd}/foo/svgeez.svg")
+    end
+
+    it 'should return a path when @destination quacks like a file.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'destination' => './foo.svg'
+      })
+
+      expect(sprite_builder.destination_file_path).to eq("#{Dir.pwd}/foo.svg")
+    end
+  end
+
+  context '#destination_folder_path' do
+    it 'should return a path when @destination is not specified.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({})
+
+      expect(sprite_builder.destination_folder_path).to eq(%{#{Dir.pwd}/_svgeez})
+    end
+
+    it 'should return a path when @destination quacks like a folder.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'destination' => './foo'
+      })
+
+      expect(sprite_builder.destination_folder_path).to eq(%{#{Dir.pwd}/foo})
+    end
+
+    it 'should return a path when @destination quacks like a file.' do
+      sprite_builder = Svgeez::SpriteBuilder.new({
+        'destination' => './foo/bar.svg'
+      })
+
+      expect(sprite_builder.destination_folder_path).to eq(%{#{Dir.pwd}/foo})
     end
   end
 end


### PR DESCRIPTION
This PR resolves #3, updating code so that `--destination` will respond to anything that appears to be a folder or a file (looking like `foo.svg`).

It also:

- updates the README
- adds (or updates) test coverage for a handful of methods
- adds a Code Climate badge ( :facepunch: )