### PR TITLE
Version 1.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,9 @@ indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
 
+[*.md]
+indent_size = 4
+indent_style = tab
+
 [*.svg]
 insert_final_newline = false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,24 +1,41 @@
-# Contributor Code of Conduct
+# Contributor Covenant Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of
-fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating
-documentation, submitting pull requests or patches, and other activities.
+## Our Pledge
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic
-  addresses, without explicit permission
-* Other unethical or unprofessional conduct
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
@@ -26,25 +43,32 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
+## Scope
 
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
 complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
 
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.3.0, available at
-[http://contributor-covenant.org/version/1/3/0/][version]
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/3/0/
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ Contributing to svgeez is pretty straightforward:
 1. Install development dependencies by running `bundle install` from the root of the project.
 1. Create a feature branch for the issue or new feature you're looking to tackle: `git checkout -b your-descriptive-branch-name`.
 1. _Write some code!_
-1. Build (`rake build`) and install (`rake install`) your updated code.
-1. If your changes would benefit from testing, add the necessary tests and verify everything passes by running `rake`.
+1. Build (`bundle exec rake build`) and install (`bundle exec rake install`) your updated code.
+1. If your changes would benefit from testing, add the necessary tests and verify everything passes by running `bundle exec rake`.
 1. Commit your changes: `git commit -am 'Add some new feature or fix some issue'`.
 1. Push the branch to your fork of svgeez: `git push origin your-descriptive-branch-name`.
 1. Create a new Pull Request and I'll give it a look!
@@ -44,6 +44,8 @@ Code styles are like opinions: Everyone's got one and yours is better than mine.
 - Prefer single quotes over double quotes unless interpolating.
 - Follow the conventions you see in the existing source code as best as you can.
 
-svgeez's formatting guidelines are defined in the `.editorconfig` file which uses the [EditorConfig](http://editorconfig.org/) syntax. There are [a number of great plugins for a variety of editors](http://editorconfig.org/#download) that utilize the settings in the `.editorconfig` file. Using EditorConfig will make your time spent coding a little bit easier.
+svgeez's formatting guidelines are defined in the `.editorconfig` file which uses the [EditorConfig](http://editorconfig.org/) syntax. There are [a number of great plugins for a variety of editors](http://editorconfig.org/#download) that utilize the settings in the `.editorconfig` file. EditorConfig takes the hassle out of syntax-specific formatting.
+
+Additionally, [Rubocop](https://github.com/bbatsov/rubocop) can be used to help identify possible trouble areas in your code. Run `bundle exec rake rubocop` to generate Rubocop's static code analysis report.
 
 Your bug fix or feature addition won't be rejected if it runs afoul of any (or all) of these guidelines, but following the guidelines will definitely make everyone's lives a little easier.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The above example will combine all SVG files in `~/Sites/sixtwothree.org/images/
 
 |Option|Description|
 |---|---|
-|`-s`<br>`--source`|Path to the folder of source SVGs (defaults to `./`).|
-|`-d`<br>`--destination`|Path to the destination file or folder (defaults to `./_svgeez/svgeez.svg`)|
+|`-s`<br>`--source`|Path to the folder of source SVGs (defaults to `./_svgeez`).|
+|`-d`<br>`--destination`|Path to the destination file or folder (defaults to `./svgeez.svg`)|
 |`--with-svgo`|Optimize source SVGs with [SVGO](https://github.com/svg/svgo/) before sprite generation (non-destructive)|
 
 ### The `watch` command

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Lastly, the sample icons in `spec/fixtures/icons` are from [Brent Jackson](https
 
 svgeez is written and maintained by [Jason Garber](https://github.com/jgarber623).
 
-### Contributors
+### Additional Contributors
 
 - [Brett Wilkins](https://github.com/bwilkins)
 

--- a/bin/svgeez
+++ b/bin/svgeez
@@ -2,8 +2,8 @@
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w(.. lib))
 
-require 'svgeez'
 require 'mercenary'
+require 'svgeez'
 
 Mercenary.program(:svgeez) do |p|
   p.version Svgeez::VERSION

--- a/lib/svgeez.rb
+++ b/lib/svgeez.rb
@@ -13,7 +13,5 @@ module Svgeez
     @logger ||= Logger.new(STDOUT)
   end
 
-  logger.formatter = proc do |_, _, _, msg|
-    "#{msg}\n"
-  end
+  logger.formatter = proc { |_, _, _, msg| "#{msg}\n" }
 end

--- a/lib/svgeez.rb
+++ b/lib/svgeez.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'listen'
 require 'logger'
+require 'mkmf'
 
 require 'svgeez/version'
 require 'svgeez/command'

--- a/lib/svgeez.rb
+++ b/lib/svgeez.rb
@@ -9,10 +9,8 @@ require 'svgeez/commands/watch'
 require 'svgeez/sprite_builder'
 
 module Svgeez
-  class << self
-    def logger
-      @logger ||= Logger.new(STDOUT)
-    end
+  def self.logger
+    @logger ||= Logger.new(STDOUT)
   end
 
   logger.formatter = proc do |_, _, _, msg|

--- a/lib/svgeez/command.rb
+++ b/lib/svgeez/command.rb
@@ -10,8 +10,8 @@ module Svgeez
     end
 
     def self.add_build_options(c)
-      c.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./)'
-      c.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./_svgeez/svgeez.svg)'
+      c.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./_svgeez)'
+      c.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./svgeez.svg)'
       c.option 'svgo', '--with-svgo', 'Optimize source SVGs with SVGO before sprite generation (non-destructive)'
     end
   end

--- a/lib/svgeez/command.rb
+++ b/lib/svgeez/command.rb
@@ -1,20 +1,18 @@
 module Svgeez
   class Command
-    class << self
-      def subclasses
-        @subclasses ||= []
-      end
+    def self.subclasses
+      @subclasses ||= []
+    end
 
-      def inherited(base)
-        subclasses << base
-        super(base)
-      end
+    def self.inherited(base)
+      subclasses << base
+      super(base)
+    end
 
-      def add_build_options(c)
-        c.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./)'
-        c.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./_svgeez/svgeez.svg)'
-        c.option 'svgo', '--with-svgo', 'Optimize source SVGs with SVGO before sprite generation (non-destructive)'
-      end
+    def self.add_build_options(c)
+      c.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./)'
+      c.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./_svgeez/svgeez.svg)'
+      c.option 'svgo', '--with-svgo', 'Optimize source SVGs with SVGO before sprite generation (non-destructive)'
     end
   end
 end

--- a/lib/svgeez/commands/watch.rb
+++ b/lib/svgeez/commands/watch.rb
@@ -16,15 +16,18 @@ module Svgeez
       end
 
       def self.process(options)
-        Svgeez.logger.info %(Watching `#{File.expand_path(options['source'])}` for changes... Press ctrl-c to stop.)
+        sprite_builder = Svgeez::SpriteBuilder.new(options)
 
-        listener = Listen.to(options['source'], only: /\.svg\z/) do
-          Svgeez::Commands::Build.process(options)
+        listener = Listen.to(sprite_builder.source, only: /\.svg\z/) do
+          sprite_builder.build
         end
+
+        Svgeez.logger.info "Watching `#{sprite_builder.source}` for changes... Press ctrl-c to stop."
 
         listener.start
         sleep
       rescue Interrupt
+        Svgeez.logger.info 'Quitting svgeez...'
       end
     end
   end

--- a/lib/svgeez/commands/watch.rb
+++ b/lib/svgeez/commands/watch.rb
@@ -1,32 +1,30 @@
 module Svgeez
   module Commands
     class Watch < Command
-      class << self
-        def init_with_program(p)
-          p.command(:watch) do |c|
-            c.description 'Watches a folder of SVG icons for changes'
-            c.syntax 'watch [options]'
+      def self.init_with_program(p)
+        p.command(:watch) do |c|
+          c.description 'Watches a folder of SVG icons for changes'
+          c.syntax 'watch [options]'
 
-            add_build_options(c)
+          add_build_options(c)
 
-            c.action do |_, options|
-              Svgeez::Commands::Build.process(options)
-              Svgeez::Commands::Watch.process(options)
-            end
-          end
-        end
-
-        def process(options)
-          Svgeez.logger.info %(Watching `#{File.expand_path(options['source'])}` for changes... Press ctrl-c to stop.)
-
-          listener = Listen.to(options['source'], only: /\.svg$/) do
+          c.action do |_, options|
             Svgeez::Commands::Build.process(options)
+            Svgeez::Commands::Watch.process(options)
           end
-
-          listener.start
-          sleep
-        rescue Interrupt
         end
+      end
+
+      def self.process(options)
+        Svgeez.logger.info %(Watching `#{File.expand_path(options['source'])}` for changes... Press ctrl-c to stop.)
+
+        listener = Listen.to(options['source'], only: /\.svg$/) do
+          Svgeez::Commands::Build.process(options)
+        end
+
+        listener.start
+        sleep
+      rescue Interrupt
       end
     end
   end

--- a/lib/svgeez/commands/watch.rb
+++ b/lib/svgeez/commands/watch.rb
@@ -18,7 +18,7 @@ module Svgeez
       def self.process(options)
         Svgeez.logger.info %(Watching `#{File.expand_path(options['source'])}` for changes... Press ctrl-c to stop.)
 
-        listener = Listen.to(options['source'], only: /\.svg$/) do
+        listener = Listen.to(options['source'], only: /\.svg\z/) do
           Svgeez::Commands::Build.process(options)
         end
 

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -1,8 +1,8 @@
 module Svgeez
   class SpriteBuilder
     def initialize(options = {})
-      @source = File.expand_path(options.fetch('source', './'))
-      @destination = File.expand_path(options.fetch('destination', './_svgeez/svgeez.svg'))
+      @source = File.expand_path(options.fetch('source', './_svgeez'))
+      @destination = File.expand_path(options.fetch('destination', './svgeez.svg'))
       @svgo = options['svgo']
     end
 

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -1,25 +1,23 @@
 module Svgeez
   class SpriteBuilder
     def initialize(options = {})
-      @source = File.expand_path(options.fetch('source', './_svgeez'))
-      @destination = File.expand_path(options.fetch('destination', './svgeez.svg'))
-      @svgo = options['svgo']
+      @options = options
     end
 
     def build
       if source_is_destination?
-        Svgeez.logger.error %(Setting `source` and `destination` to the same path isn't allowed!)
+        Svgeez.logger.error "Setting `source` and `destination` to the same path isn't allowed!"
       elsif source_file_paths.empty?
-        Svgeez.logger.warn %(No SVGs were found in `#{@source}`.)
+        Svgeez.logger.warn "No SVGs were found in `#{source}`."
       else
-        Svgeez.logger.info %(Generating sprite at `#{destination_file_path}` from #{source_file_paths.length} SVG#{'s' if source_file_paths.length > 1}...)
+        Svgeez.logger.info "Generating sprite at `#{destination_file_path}` from #{source_file_paths.length} SVG#{'s' if source_file_paths.length > 1}..."
 
         # Make destination folder
         FileUtils.mkdir_p(destination_folder_path)
 
         # Notify if SVGO requested but not found
-        if @svgo && !svgo_installed?
-          Svgeez.logger.warn %(Unable to find `svgo` in your PATH. Continuing with standard sprite generation...)
+        if svgo_use? && !svgo_installed?
+          Svgeez.logger.warn 'Unable to find `svgo` in your PATH. Continuing with standard sprite generation...'
         end
 
         # Write the file
@@ -27,28 +25,36 @@ module Svgeez
           f.write build_destination_file_contents
         end
 
-        Svgeez.logger.info %(Successfully generated sprite at `#{destination_file_path}`.)
+        Svgeez.logger.info "Successfully generated sprite at `#{destination_file_path}`."
       end
+    end
+
+    def destination
+      @destination ||= File.expand_path(@options.fetch('destination', './svgeez.svg'))
+    end
+
+    def source
+      @source ||= File.expand_path(@options.fetch('source', './_svgeez'))
     end
 
     private
 
     def build_destination_file_contents
-      destination_file_contents = '<svg>'
+      destination_file_contents = "<svg>#{collect_source_files_contents.join}</svg>"
 
-      source_file_paths.each do |file_path|
-        IO.read(file_path).match(%r{^<svg.*?(?<viewbox>viewBox=".*?").*?>(?<content>.*?)</svg>}m) do |matches|
-          destination_file_contents << %(<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').gsub(/['"\s]/, '-')}" #{matches[:viewbox]}>#{matches[:content]}</symbol>)
-        end
-      end
-
-      destination_file_contents << '</svg>'
-
-      if @svgo && svgo_installed?
+      if svgo_use? && svgo_installed?
         destination_file_contents = `cat <<EOF | svgo --disable=cleanupIDs -i - -o -\n#{destination_file_contents}\nEOF`
       end
 
       destination_file_contents.insert(4, %( id="#{destination_file_id}" style="display: none;" version="1.1"))
+    end
+
+    def collect_source_files_contents
+      source_file_paths.collect do |file_path|
+        IO.read(file_path).match(%r{^<svg.*?(?<viewbox>viewBox=".*?").*?>(?<content>.*?)</svg>}m) do |matches|
+          %(<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').gsub(/['"\s]/, '-')}" #{matches[:viewbox]}>#{matches[:content]}</symbol>)
+        end
+      end
     end
 
     def destination_file_id
@@ -56,8 +62,8 @@ module Svgeez
     end
 
     def destination_file_name
-      if @destination.end_with?('.svg')
-        File.split(@destination)[1]
+      if destination.end_with?('.svg')
+        File.split(destination)[1]
       else
         'svgeez.svg'
       end
@@ -68,19 +74,23 @@ module Svgeez
     end
 
     def destination_folder_path
-      if @destination.end_with?('.svg')
-        File.split(@destination)[0]
+      if destination.end_with?('.svg')
+        File.split(destination)[0]
       else
-        @destination
+        destination
       end
     end
 
     def source_file_paths
-      @source_file_paths ||= Dir.glob(File.join(@source, '*.svg'))
+      @source_file_paths ||= Dir.glob(File.join(source, '*.svg'))
     end
 
     def source_is_destination?
-      /\A#{@source}/ =~ destination_folder_path
+      /\A#{source}/ =~ destination_folder_path
+    end
+
+    def svgo_use?
+      @svgo_use ||= @options['svgo']
     end
 
     def svgo_installed?

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -80,7 +80,7 @@ module Svgeez
     end
 
     def source_is_destination?
-      /^#{@source}/ =~ destination_folder_path
+      /\A#{@source}/ =~ destination_folder_path
     end
 
     def svgo_installed?

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -1,6 +1,6 @@
 module Svgeez
   class SpriteBuilder
-    def initialize(options)
+    def initialize(options = {})
       @source = File.expand_path(options.fetch('source', './'))
       @destination = File.expand_path(options.fetch('destination', './_svgeez/svgeez.svg'))
       @svgo = options['svgo']

--- a/lib/svgeez/version.rb
+++ b/lib/svgeez/version.rb
@@ -1,3 +1,3 @@
 module Svgeez
-  VERSION = '0.2.7'
+  VERSION = '0.3.0'.freeze
 end

--- a/lib/svgeez/version.rb
+++ b/lib/svgeez/version.rb
@@ -1,3 +1,3 @@
 module Svgeez
-  VERSION = '0.3.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/lib/svgeez/sprite_builder_spec.rb
+++ b/spec/lib/svgeez/sprite_builder_spec.rb
@@ -40,7 +40,6 @@ describe Svgeez::SpriteBuilder do
         )
       end
 
-      let(:file_utils) { double(FileUtils) }
       let(:file) { double(File) }
 
       before do
@@ -71,7 +70,7 @@ describe Svgeez::SpriteBuilder do
 
   describe '#destination_file_id' do
     context 'when @destination is not specified' do
-      let(:sprite_builder) { Svgeez::SpriteBuilder.new({}) }
+      let(:sprite_builder) { Svgeez::SpriteBuilder.new }
 
       it 'returns a string.' do
         expect(sprite_builder.send(:destination_file_id)).to eq 'svgeez'
@@ -119,10 +118,10 @@ describe Svgeez::SpriteBuilder do
 
   describe '#destination_file_path' do
     context 'when @destination is not specified' do
-      let(:sprite_builder) { Svgeez::SpriteBuilder.new({}) }
+      let(:sprite_builder) { Svgeez::SpriteBuilder.new }
 
       it 'returns a path.' do
-        expect(sprite_builder.send(:destination_file_path)).to eq "#{Dir.pwd}/_svgeez/svgeez.svg"
+        expect(sprite_builder.send(:destination_file_path)).to eq "#{Dir.pwd}/svgeez.svg"
       end
     end
 
@@ -153,10 +152,10 @@ describe Svgeez::SpriteBuilder do
 
   describe '#destination_folder_path' do
     context 'when @destination is not specified' do
-      let(:sprite_builder) { Svgeez::SpriteBuilder.new({}) }
+      let(:sprite_builder) { Svgeez::SpriteBuilder.new }
 
       it 'returns a path.' do
-        expect(sprite_builder.send(:destination_folder_path)).to eq "#{Dir.pwd}/_svgeez"
+        expect(sprite_builder.send(:destination_folder_path)).to eq Dir.pwd
       end
     end
 
@@ -186,20 +185,40 @@ describe Svgeez::SpriteBuilder do
   end
 
   describe '#source_file_paths' do
-    let :sprite_builder do
-      Svgeez::SpriteBuilder.new(
-        'source' => './spec/fixtures/icons'
-      )
-    end
+    context 'when @source is not specified' do
+      let(:sprite_builder) { Svgeez::SpriteBuilder.new }
 
-    let :file_paths do
-      %w(facebook github heart skull twitter).collect do |i|
-        File.expand_path("./spec/fixtures/icons/#{i}.svg")
+      let :file_paths do
+        %w(facebook github heart skull twitter).collect do |i|
+          File.expand_path("./_svgeez/#{i}.svg")
+        end
+      end
+
+      before do
+        allow(Dir).to receive(:glob).and_return(file_paths)
+      end
+
+      it 'returns an array of file paths.' do
+        expect(sprite_builder.send(:source_file_paths)).to eq file_paths
       end
     end
 
-    it 'returns an array of of file paths.' do
-      expect(sprite_builder.send(:source_file_paths)).to eq file_paths
+    context 'when @source is specified' do
+      let :sprite_builder do
+        Svgeez::SpriteBuilder.new(
+          'source' => './spec/fixtures/icons'
+        )
+      end
+
+      let :file_paths do
+        %w(facebook github heart skull twitter).collect do |i|
+          File.expand_path("./spec/fixtures/icons/#{i}.svg")
+        end
+      end
+
+      it 'returns an array of file paths.' do
+        expect(sprite_builder.send(:source_file_paths)).to eq file_paths
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'svgeez'
+
+CodeClimate::TestReporter.start
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
This is a major refactoring (thus the version bump) of svgeez. It…

- heavily refactors `lib/svgeez/sprite_builder.rb`,
- improves test coverage on `SpriteBuilder`,
- implements _many_ of Rubocop's syntax suggestions,
- re-adds `mkmf` requirement as it provides the `find_executable0` method used to determine if `svgo` is installed,
- changes default `source` and `destination`, fixing a longtime logical error where `destination` could be nested within `source` (**This is a breaking change!**).