### PR TITLE
SVGO location

### DIFF
--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -43,7 +43,7 @@ module Svgeez
       destination_file_contents = "<svg>#{collect_source_files_contents.join}</svg>"
 
       if svgo_use? && svgo_installed?
-        destination_file_contents = `cat <<EOF | svgo --disable=cleanupIDs -i - -o -\n#{destination_file_contents}\nEOF`
+        destination_file_contents = `cat <<EOF | #{svgo_executable} --disable=cleanupIDs -i - -o -\n#{destination_file_contents}\nEOF`
       end
 
       destination_file_contents.insert(4, %( id="#{destination_file_id}" style="display: none;" version="1.1"))
@@ -94,7 +94,35 @@ module Svgeez
     end
 
     def svgo_installed?
-      @svgo_installed ||= find_executable0('svgo')
+      @svgo_installed ||= svgo_executable
+    end
+
+    def svgo_executable
+      @svgo_executable ||= find_svgo_executable
+    end
+
+    def find_svgo_executable
+      specified_executable || local_svgo_executable || global_svgo_executable
+    end
+
+    def specified_executable
+      svgo_path = specified_svgo_path
+      find_executable0('svgo', svgo_path) if svgo_path
+    end
+
+    def specified_svgo_path
+      return unless @options['svgo']
+      path = File.expand_path(@options['svgo'])
+      return unless File.directory?(path)
+      path
+    end
+
+    def local_svgo_executable
+      find_executable0('svgo', File.expand_path('./node_modules/svgo/bin', Dir.pwd))
+    end
+
+    def global_svgo_executable
+      find_executable0('svgo')
     end
   end
 end

--- a/lib/svgeez/version.rb
+++ b/lib/svgeez/version.rb
@@ -1,3 +1,3 @@
 module Svgeez
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
Hello,

Nice library!

Currently SVGO needs to be installed globally in order to be used. The change I made makes use of the `svgo` parameter, which can now be used to specify the path where svgo is found. The SVGO to be used is chosen in order of precedence:
1. The specified SVGO parameter, if it is an absolute or relative path
2. The SVGO under `./node_modules/svgo/bin`
3. The globally installed SVGO (current)

I have added (locally) the following tests, but did not commit them as they require svgo.

```
  describe '#build_destination_file_contents_with_svgo_set_to_true' do
    let :sprite_builder do
      Svgeez::SpriteBuilder.new(
        'source' => './spec/fixtures/icons',
        'destination' => './spec/fixtures/icons.svg',
        'svgo' => 'true',
      )
    end

    it 'returns a string representation of combined SVG files.' do
      expect(sprite_builder.send(:build_destination_file_contents)).to eq IO.read('./spec/fixtures/icons_svgo.svg')
    end
  end

  describe '#build_destination_file_contents_with_svgo_absolute_path' do
    let :sprite_builder do
      Svgeez::SpriteBuilder.new(
        'source' => './spec/fixtures/icons',
        'destination' => './spec/fixtures/icons.svg',
        'svgo' => '/Users/fragkakis/Documents/workable/node_modules/svgo/bin',
      )
    end

    it 'returns a string representation of combined SVG files.' do
      expect(sprite_builder.send(:build_destination_file_contents)).to eq IO.read('./spec/fixtures/icons_svgo.svg')
    end
  end

  describe '#build_destination_file_contents_with_svgo_relative_path' do
    let :sprite_builder do
      Svgeez::SpriteBuilder.new(
        'source' => './spec/fixtures/icons',
        'destination' => './spec/fixtures/icons.svg',
        'svgo' => '../workable/node_modules/svgo/bin',
      )
    end

    it 'returns a string representation of combined SVG files.' do
      expect(sprite_builder.send(:build_destination_file_contents)).to eq IO.read('./spec/fixtures/icons_svgo.svg')
    end
  end
```
