### PR TITLE
Add unique ids to path elements so they never conflict.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# svgeez
+# svgeez [figma](https://www.figma.com/) edition
 
 **A Ruby gem for automatically generating an SVG sprite from a folder of SVG icons.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# svgeez [figma](https://www.figma.com/) edition
+# svgeez
 
 **A Ruby gem for automatically generating an SVG sprite from a folder of SVG icons.**
 

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Svgeez
   class SpriteBuilder
     DEFAULT_DESTINATION_FILE_NAME = 'svgeez.svg'.freeze
@@ -52,8 +54,16 @@ module Svgeez
 
     def collect_source_files_contents
       source_file_paths.collect do |file_path|
-        IO.read(file_path).match(%r{^<svg.*?(?<viewbox>viewBox=".*?").*?>(?<content>.*?)</svg>}m) do |matches|
-          %(<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').gsub(/['"\s]/, '-')}" #{matches[:viewbox]}>#{matches[:content]}</symbol>)
+        IO.read(file_path).match(%r{^<svg.*?(?<viewbox>viewBox=".*?").*?>(?<content>.*?)</svg>}m) do |svg|
+          svg_content = svg[:content]
+          path_ids = svg_content.scan(/path id="(.+?)"/)
+
+          Array(path_ids).each do |path_id, index|
+            unique_path_id = "path_id-#{SecureRandom.uuid}"
+            svg_content.gsub!(Regexp.new(path_id), unique_path_id)
+          end
+
+          %(<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').gsub(/['"\s]/, '-')}" #{svg[:viewbox]}>#{svg_content}</symbol>)
         end
       end
     end

--- a/lib/svgeez/sprite_builder.rb
+++ b/lib/svgeez/sprite_builder.rb
@@ -58,14 +58,20 @@ module Svgeez
           svg_content = svg[:content]
           path_ids = svg_content.scan(/path id="(.+?)"/)
 
-          Array(path_ids).each do |path_id, index|
-            unique_path_id = "path_id-#{SecureRandom.uuid}"
-            svg_content.gsub!(Regexp.new(path_id), unique_path_id)
-          end
+          svg_content = add_unique_ids(svg_content, path_ids)
 
           %(<symbol id="#{destination_file_id}-#{File.basename(file_path, '.svg').gsub(/['"\s]/, '-')}" #{svg[:viewbox]}>#{svg_content}</symbol>)
         end
       end
+    end
+
+    def add_unique_ids(svg_content, path_ids)
+      Array(path_ids).each do |path_id, _|
+        unique_path_id = "path_id-#{SecureRandom.uuid}"
+        svg_content.gsub!(Regexp.new(path_id), unique_path_id)
+      end
+
+      svg_content
     end
 
     def destination_file_id


### PR DESCRIPTION
This PR addresses issues using svgeez with SVG files that use `path` element ids internally. When combining SVGs that use path ids internally, those ids can conflict, and result in incorrect SVGs rendering onto the page.

When this occurs, every one of the combined SVGs would render as the first SVG in the file (in my somewhat unique case).

I noticed this when using SVGs exported by the application [Figma](https://www.figma.com), but the same issue could exist with other SVGs.

For example, if you have several SVGs with a structure similar to the following:
```
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
<g id="Canvas" transform="translate(-14471 -5143)" figma:type="canvas">
<g id="Vector" style="mix-blend-mode:normal;" figma:type="vector">
<use xlink:href="#path0_fill" transform="matrix(-1 0 0 1 14483.6 5143)" fill="#43697E" style="mix-blend-mode:normal;"/>
</g>
</g>
<defs>
<path id="path0_fill" d="M 10.6765 7.85764L7.72363Z"/>
</defs>
</svg>
```

Because the `use` element is referencing the `path` element `id`, when multiple of these SVGs are combined, the ids always reference the `path` element of the first SVG, instead of the one that used to be contained within its own file.

To fix this issue, I am using `gsub` to add a unique id to every `path` `id` within a given file.