### PR TITLE
Ability to configure svg sprite's symbol `id` attribute

### DIFF
--- a/lib/svgeez/builder.rb
+++ b/lib/svgeez/builder.rb
@@ -4,12 +4,13 @@ module Svgeez
     SOURCE_DOES_NOT_EXIST = 'Provided `source` folder does not exist.'.freeze
     NO_SVGS_IN_SOURCE_MESSAGE = 'No SVGs were found in `source` folder.'.freeze
 
-    attr_reader :source, :destination
+    attr_reader :source, :destination, :prefix
 
     def initialize(options = {})
       @source = Source.new(options)
       @destination = Destination.new(options)
       @svgo = options.fetch('svgo', false)
+      @prefix = options.fetch('prefix', @destination.file_id)
 
       raise SOURCE_IS_DESTINATION_MESSAGE if source_is_destination?
       raise SOURCE_DOES_NOT_EXIST unless source_exists?
@@ -41,7 +42,7 @@ module Svgeez
     private
 
     def destination_file_contents
-      file_contents = Elements::SvgElement.new(source, destination).build
+      file_contents = Elements::SvgElement.new(source, destination, prefix).build
       file_contents = Optimizer.new.optimize(file_contents) if @svgo
 
       file_contents.insert(4, ' style="display: none;"')

--- a/lib/svgeez/command.rb
+++ b/lib/svgeez/command.rb
@@ -31,6 +31,7 @@ module Svgeez
       def add_options(command)
         command.option 'source', '-s', '--source [FOLDER]', 'Source folder (defaults to ./_svgeez)'
         command.option 'destination', '-d', '--destination [OUTPUT]', 'Destination file or folder (defaults to ./svgeez.svg)'
+        command.option 'prefix', '-p', '--prefix [PREFIX]', 'Custom Prefix for icon id (defaults to destination filename)'
         command.option 'svgo', '--with-svgo', 'Optimize source SVGs with SVGO before sprite generation (non-destructive)'
       end
     end

--- a/lib/svgeez/elements/svg_element.rb
+++ b/lib/svgeez/elements/svg_element.rb
@@ -1,9 +1,10 @@
 module Svgeez
   module Elements
     class SvgElement
-      def initialize(source, destination)
+      def initialize(source, destination, prefix)
         @source = source
         @destination = destination
+        @prefix = prefix
       end
 
       def build
@@ -14,7 +15,7 @@ module Svgeez
 
       def symbol_elements
         @source.file_paths.map do |file_path|
-          SymbolElement.new(file_path, @destination.file_id).build
+          SymbolElement.new(file_path, @prefix).build
         end
       end
     end

--- a/lib/svgeez/elements/symbol_element.rb
+++ b/lib/svgeez/elements/symbol_element.rb
@@ -16,8 +16,11 @@ module Svgeez
 
       def element_attributes(attributes)
         attrs = attributes.scan(/(?:viewBox|xmlns:.+?)=".*?"/m)
+        id_prefix = @file_id
+        id_suffix = File.basename(@file_path, '.svg').gsub(/['"\s]/, '-')
+        id_attribute = [id_prefix, id_suffix].reject(&:empty?).join('-')
 
-        attrs << %(id="#{@file_id}-#{File.basename(@file_path, '.svg').gsub(/['"\s]/, '-')}")
+        attrs << %(id="#{id_attribute}")
       end
 
       def element_contents(content)

--- a/spec/lib/svgeez/builder_build_spec.rb
+++ b/spec/lib/svgeez/builder_build_spec.rb
@@ -118,4 +118,22 @@ RSpec.describe Svgeez::Builder, '#build' do
       end
     end
   end
+
+  describe '--prefix option' do
+    context 'when --prefix option is not used' do
+      it 'assigns destination file_id as @prefix' do
+        builder = described_class.new
+
+        expect(builder.prefix).to eq(builder.destination.file_id)
+      end
+    end
+
+    context 'when --prefix option is used' do
+      it 'assigns provided value as @prefix' do
+        builder = described_class.new('prefix' => 'icon')
+
+        expect(builder.prefix).to eq('icon')
+      end
+    end
+  end
 end

--- a/spec/lib/svgeez/elements/svg_element_build_spec.rb
+++ b/spec/lib/svgeez/elements/svg_element_build_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Svgeez::Elements::SvgElement, '#build' do
   let(:destination) { instance_double(Svgeez::Destination) }
   let(:symbol_element) { instance_double(Svgeez::Elements::SymbolElement) }
 
-  let(:svg_element) { described_class.new(source, destination) }
+  let(:svg_element) { described_class.new(source, destination, destination.file_id) }
 
   before do
     allow(Svgeez::Source).to receive(:new).and_return(source)

--- a/spec/lib/svgeez/elements/symbol_element_build_spec.rb
+++ b/spec/lib/svgeez/elements/symbol_element_build_spec.rb
@@ -2,13 +2,27 @@ RSpec.describe Svgeez::Elements::SymbolElement, '#build' do
   let(:uuid) { '1234-abcd-5678-efgh' }
   let(:file_path) { File.expand_path('./spec/fixtures/icons/facebook.svg') }
   let(:file_id) { 'foo' }
-  let(:symbol_element) { described_class.new(file_path, file_id) }
 
   before do
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
   end
 
   it 'returns a string' do
+    symbol_element = described_class.new(file_path, file_id)
     expect(symbol_element.build).to eq(%(<symbol id="foo-facebook" viewBox="0 0 10 18" xmlns:xlink="http://www.w3.org/1999/xlink">\n<g>\n\s\s<use xlink:href="#Path_1-#{uuid}" fill="#626262"/>\n</g>\n<defs>\n\s\s<path id="Path_1-#{uuid}" filter="url(#blurMe-#{uuid})" d="M0.896,6.12h1.758V4.411c0-0.754,0.019-1.916,0.567-2.635c0.576-0.762,1.368-1.28,2.729-1.28\n\s\s\s\sc2.22,0,3.153,0.316,3.153,0.316l-0.44,2.605c0,0-0.732-0.212-1.416-0.212S5.95,3.45,5.95,4.134V6.12h2.805L8.56,8.665H5.95v8.839\n\s\s\s\sH2.654V8.665H0.896V6.12z"/>\n\s\s<filter id="blurMe-#{uuid}">\n\s\s\s\s<feGaussianBlur in="SourceGraphic" stdDeviation="5"/>\n\s\s</filter>\n</defs>\n</symbol>))
+  end
+
+  context 'when file_id is blank' do
+    it 'only uses filename of file_path as id attribute' do
+      symbol_element = described_class.new(file_path, '')
+      expect(symbol_element.build).to match(/id="facebook"/)
+    end
+  end
+
+  context 'when file_id is provided' do
+    it 'includes file_id in id attribute' do
+      symbol_element = described_class.new(file_path, 'icon')
+      expect(symbol_element.build).to match(/id="icon-facebook"/)
+    end
   end
 end


### PR DESCRIPTION
## Related Issue 

#79 [FEATURE REQUEST] Ability to configure svg sprite's symbol `id` attribute 

## Description

✅ Add `--prefix` option to _build_ command. This option will accept prefix for symbol id attribute

`<symbol id="[PREFIX]-[ICON-FILENAME]"></symbol>`


✅ Change symbol `id` generation logic
  1. Retain initial convention **[PREFIX]-[FILENAME]** for id generation
  2. If either **PREFIX** or **FILENAME** is empty, drop it from final id.


✅ Add/Modify specs to reflect changes