### PR TITLE
Add Rails 7 example with Propshaft

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ In a Rails 4.2.x or 5 application:
 </body>
 ```
 
+In a Rails 7 application with Propshaft:
+
+```html
+<body>
+  <!-- Your page’s awesome content goes here! -->
+
+  <%= raw Rails.application.assets.load_path.find('icons.svg').content %>
+</body>
+```
+
 Or, with PHP:
 
 ```html


### PR DESCRIPTION
This adds an example of using Rails 7 with [Propshaft](https://github.com/rails/propshaft/blob/main/UPGRADING.md#3-migrate-from-sprockets-to-propshaft). Thanks for this project!